### PR TITLE
Fix using undefined hub variable

### DIFF
--- a/drivers/harmony_device_driver/device.js
+++ b/drivers/harmony_device_driver/device.js
@@ -11,7 +11,7 @@ class HarmonyDevice extends Homey.Device {
         this.setUnavailable(`Hub ${Homey.__("offline")}`);
 
         Homey.app.on(`${this._deviceData.id}_online`, (hub) => {
-            this.hub = hub;
+            this.hub = Homey.app.getHub(this._deviceData.hubId);
             this.setAvailable();
         });
 


### PR DESCRIPTION
During device init, `this.hub` should reference the hub used to control
the device. Previously this referenced an undefined variable resulting
in issues in the app. The fix includes gathering the hub using `getHub`
function and the hub ID.

Fix #65