### PR TITLE
Update onoff capability listener to parse value

### DIFF
--- a/drivers/harmony_device_driver/device.js
+++ b/drivers/harmony_device_driver/device.js
@@ -229,19 +229,29 @@ class HarmonyDevice extends Homey.Device {
                 powerCommand = powerOffFunction !== undefined ? powerOffFunction : powerToggleFunction;
             }
 
-            hubManager.connectToHub(foundHub.ip).then((hub) => {
-                hub.commandAction(powerCommand).catch((err) => {
-                    console.log(err);
-                    return Promise.reject(err);
-                });
-            });
-
             // Only trigger onOff state actions if state actually changes
             let currentOnOffState = this.getCapabilityValue('onoff');
             if (currentOnOffState !== setOnOffState) {
                 let deviceState = {};
                 deviceState.Power = setOnOffState ? 'On' : 'Off';
                 this.triggerOnOffAction(deviceState);
+
+                hubManager.connectToHub(foundHub.ip).then((hub) => {
+                    hub.commandAction(powerCommand).catch((err) => {
+                        console.log(err);
+                        return Promise.reject(err);
+                    });
+                });
+
+            // Even if currentState eq setState, all specific on/off command may be executed
+            // toggleCommands should not be executed because this might turn device in unwanted state
+            } else if (powerCommand !== powerToggleFunction){
+                hubManager.connectToHub(foundHub.ip).then((hub) => {
+                    hub.commandAction(powerCommand).catch((err) => {
+                        console.log(err);
+                        return Promise.reject(err);
+                    });
+                });
             }
 
             return Promise.resolve();


### PR DESCRIPTION
The onoff capability listener now takes the expected onoff value, as
given by Homey, into account of whether to turn devices on or off.
Previously the `onCapabilityOnoff` function switches the device state,
which in turn results in devices turning on when askes to turn off
twice.

Now the expected value is taken into account whether to turn the devices
on or off.

Fix #73